### PR TITLE
disable autocomplete defaults

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -92,6 +92,7 @@ var stopSubCmd = &cobra.Command{
 }
 
 func init() {
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
 	rootCmd.AddCommand(serveCmd)
 	serveCmd.AddCommand(startSubCmd)
 	serveCmd.AddCommand(stopSubCmd)


### PR DESCRIPTION
This removes completion command, cobra default.

[x] Have you updated any appropriate docs
[x] Are comments up to date
[x] Did you run `go fmt`
